### PR TITLE
Update documentation for Secrets

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -11,11 +11,10 @@ Every pad on Launchpad is owned by the user that created it. The code and endpoi
 We’ve included a feature called secrets that lets the owner of a pad put in API keys and other sensitive information which is hidden from everyone else. So while anyone can read the code and call the endpoint, they can’t extract database passwords or API keys. TK add information about how we do this.
 
 Adding a secret can be done by clicking the "secrets" button in the lower right of the launchpad dashboard.
-[secrets-button](http://i.imgur.com/jMCXf8i.png)
+![secrets-button](http://i.imgur.com/jMCXf8i.png)
 
 Enter a key and value for the secret. 
-[launchpad access key modal](http://i.imgur.com/kKUUSuy.png)
-
+![launchpad access key modal](http://i.imgur.com/kKUUSuy.png)
 
 ## Fork to edit
 

--- a/docs.md
+++ b/docs.md
@@ -10,6 +10,13 @@ Every pad on Launchpad is owned by the user that created it. The code and endpoi
 
 We’ve included a feature called secrets that lets the owner of a pad put in API keys and other sensitive information which is hidden from everyone else. So while anyone can read the code and call the endpoint, they can’t extract database passwords or API keys. TK add information about how we do this.
 
+Adding a secret can be done by clicking the "secrets" button in the lower right of the launchpad dashboard.
+[secrets-button](http://i.imgur.com/jMCXf8i.png)
+
+Enter a key and value for the secret. 
+[launchpad access key modal](http://i.imgur.com/kKUUSuy.png)
+
+
 ## Fork to edit
 
 If you’re viewing someone else’s pad, you can log in and click “Fork” to make a copy that you own. In the process, any secrets will be deleted, and you will need to provide your own values for those keys. For example, if you fork the MongoDB example, you’ll need to go to a MongoDB hosting provider like mLab, create a database, and put in the new database URL.

--- a/docs.md
+++ b/docs.md
@@ -19,11 +19,11 @@ const resolvers = {
   Query: {
     user: (root, args, context) => {
       return fetch(`https://api.netlify.com/api/v1/user?access_token=${context.secrets.ACCESS_TOKEN}`)
-      	.then(res => res.json()).catch(err => console.log(err));
+      	.then(res => res.json());
     },
   },
 }
-...
+
 export function context(headers, secrets) {
   return {
     headers,

--- a/docs.md
+++ b/docs.md
@@ -10,11 +10,27 @@ Every pad on Launchpad is owned by the user that created it. The code and endpoi
 
 We’ve included a feature called secrets that lets the owner of a pad put in API keys and other sensitive information which is hidden from everyone else. So while anyone can read the code and call the endpoint, they can’t extract database passwords or API keys. TK add information about how we do this.
 
-Adding a secret can be done by clicking the "secrets" button in the lower right of the launchpad dashboard.
-![secrets-button](http://i.imgur.com/jMCXf8i.png)
-
-Enter a key and value for the secret. 
+Adding a secret can be done by clicking the "secrets" button in the lower right of the launchpad dashboard and enter a key and value for your secret. 
 ![launchpad access key modal](http://i.imgur.com/kKUUSuy.png)
+
+Accessing your secrets within your code can be done by exposing the secrets or headers object in context. See the [CurrentWeather](https://launchpad.graphql.com/5rrx10z19) examples for a live example.
+```js
+const resolvers = {
+  Query: {
+    user: (root, args, context) => {
+      return fetch(`https://api.netlify.com/api/v1/user?access_token=${context.secrets.ACCESS_TOKEN}`)
+      	.then(res => res.json()).catch(err => console.log(err));
+    },
+  },
+}
+...
+export function context(headers, secrets) {
+  return {
+    headers,
+    secrets,
+  };
+};
+```
 
 ## Fork to edit
 

--- a/docs.md
+++ b/docs.md
@@ -13,7 +13,7 @@ We’ve included a feature called secrets that lets the owner of a pad put in AP
 Adding a secret can be done by clicking the "secrets" button in the lower right of the launchpad dashboard and enter a key and value for your secret. 
 ![launchpad access key modal](http://i.imgur.com/kKUUSuy.png)
 
-Accessing your secrets within your code can be done by exposing the secrets or headers object in context. See the [CurrentWeather](https://launchpad.graphql.com/5rrx10z19) examples for a live example.
+Accessing your secrets within your code can be done by exposing the secrets or headers object in context. See the [CurrentWeather](https://launchpad.graphql.com/5rrx10z19) example for a live example.
 ```js
 const resolvers = {
   Query: {


### PR DESCRIPTION
I know this project is still in active development but I noticed some blind spots in the documentation. I am starting to leverage this to provide some GraphQL examples for the Netlify team to play with and want to add some clarity to this. 

For more context: I created a forum questions -- which I answered as well. https://forums.meteor.com/t/accessing-headers-secrets-in-the-apollo-launchpad/37743