### PR TITLE
Migrate to latest upstream Babel

### DIFF
--- a/frontend/services/eject/dotBabelrc.js
+++ b/frontend/services/eject/dotBabelrc.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 export default `{
-  presets: ['latest'],
+  presets: ['env'],
   plugins: [
     'transform-runtime',
     'transform-async-generator-functions',

--- a/frontend/services/eject/packageDotJson.js
+++ b/frontend/services/eject/packageDotJson.js
@@ -17,7 +17,7 @@ export default `{
     "babel-plugin-transform-async-generator-functions": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-latest": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
     "nodemon": "^1.11.0"
   },
   "dependencies": {


### PR DESCRIPTION
**TL, DR**
This PR is intended to silence a couple of cosmetic runtime warnings that Launchpad users encounter as of Jan 2018 when they download and run their Launchpads with the 'Download' link.
I know tests are usually required for PRs, in this case I didn't write one because there is no new bug per se. Rather this is cosmetic -  removes a node warning on runtime.

**Back story**
Towards the end of 2017, the Babel maintainers simplified
how Babel is distributed ([details](1)). The recommended way to use it
now is with a new package whose name is expected to stay stable.
The package is now called
`babel-preset-env`
The idea is to reduce the long-term maintenance dance by updating Babel and its config manually every year.

[1] http://babeljs.io/env